### PR TITLE
Revise readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Craft Docker Images
 
-These images are used for a baseline to extend for your Docker deployments.
+These images are provided as a starting point for your Docker-based Craft CMS deployments. They’re discrete, lightweight, and preconfigured to meet Craft’s requirements in production and development environments.
 
 ## Images
 
@@ -17,11 +17,11 @@ These images are used for a baseline to extend for your Docker deployments.
 
 ## Usage
 
-Craft provides two main types of images, a `php-fpm` and `cli` image. The `php-fpm` image is used to handle the web application and the `cli` is used to run queues.
+There are two main types of images: `php-fpm` for handling the web application, and `cli` for running queues and other Craft CLI commands.
 
-> Note: We purposely do not provide a web server image as that choice depends on your project needs. We do provide documentation on how to use Nginx and Caddy with this image
+> Note: We purposely do not provide a web server image because that choice depends on your project needs. We do, however, provide examples illustrating how to use Nginx or Caddy with the `php-fpm` images.
 
-This example uses a Docker multi-stage build to install composer dependencies inside a seperate layer and then copy them into the final image.
+This example uses a Docker [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) to install composer dependencies inside a seperate layer before copying them into the final image.
 
 ```dockerfile
 # use a multi-stage build for dependencies
@@ -32,25 +32,25 @@ RUN composer install --ignore-platform-reqs --no-interaction --prefer-dist
 
 FROM craftcms/php-fpm:7.4
 
-# the user is www-data, so we copy the files using the user and group
+# the user is `www-data`, so we copy the files using the user and group
 COPY --chown=www-data:www-data --from=vendor /app/vendor/ /app/vendor/
 COPY --chown=www-data:www-data . .
 ```
 
 ## Permissions
 
-The image is set to run as the user `www-data`. There is a directory already precreated and prepared for the `www-data` user. Running as non-root is considered a Docker best practice, especially when shipping container images to production.
+The image is designed to be run by a `www-data` user that owns of the image’s `/app` directory. Running as non-root is considered a Docker best practice, especially when shipping container images to production.
 
 > Note: You can use the `USER root` directive to switch back to `root` to install any additional packages you need.
 
 ## Running Locally with Docker Compose
 
-Running Docker locally is recommended if you are shipping your project to a Docker based envrionment such as Amazon Web Services Elastic Container Services (ECS). The following Docker Compose file will setup your local environment with the following:
+We recommend running Docker locally if you’re shipping your project to a Docker-based envrionment such as Amazon Web Services Elastic Container Services (ECS). The following Docker Compose file will setup your local environment with the following:
 
-1. `php-fpm` service that will handle running PHP
-2. `nginx` service that will accept HTTP requests on port 8000
+1. `nginx` service that will accept HTTP requests on port 8000
+2. `php-fpm` service that will handle running PHP
 3. `mysql` service that will store your content
-4. `queue` service that will run the queue locally
+4. `console` service that will run the queue locally
 5. `redis` service that will handle queue and caching
 
 ```yaml
@@ -68,7 +68,7 @@ services:
     volumes:
       - ./path/to/nginx.conf:/etc/nginx/conf.d/default.conf
       - .:/app
-  queue:
+  console:
     image: craftcms/cli:7.4-dev
     volumes:
       - .:/app
@@ -93,16 +93,22 @@ volumes:
   db_data:
 ```
 
-You will need to provide an nginx.conf file that points the `php-fpm` service, not `localhost` or `127.0.0.1`. We can borrow the following example from [nystudio107/nginx-craft](https://github.com/nystudio107/nginx-craft) in the `sites-available/basic_localdev.com.conf` and update it to use
+You will need to provide an `nginx.conf` file that points the `php-fpm` service, not `localhost` or `127.0.0.1`. We can borrow the following example from [nystudio107/nginx-craft](https://github.com/nystudio107/nginx-craft)’s `sites-available/basic_localdev.com.conf` with a few adjustments:
+
+- remove comments for readibility
+- use a catch-all `server_name` of `_`
+- set `/app/web` as the web root
+- log to stdout
+- direct PHP to our named `php-fpm` service instead of localhost (on its default port `9000`)
+- unset the `HTTP_HOST` header
+- remove Dotenvy, `.htaccess` file skipping, and `sendfile off` that aren’t needed
 
 ```nginx
-# removed comments for readability except where we modify the config
 server {
     listen 80;
     listen [::]:80;
 
     server_name _;
-    # we change the root to match the root for the php-fpm service
     root /app/web;
     index index.html index.htm index.php;
     charset utf-8;
@@ -118,16 +124,13 @@ server {
     access_log off;
     error_log /dev/stdout info;
 
-    # Root directory location handler
     location / {
         try_files $uri/index.html $uri $uri/ /index.php?$query_string;
     }
 
-    # php-fpm configuration
     location ~ [^/]\.php(/|$) {
         try_files $uri $uri/ /index.php?$query_string;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        # instead of localhost of 127.0.0.1, we use the name of the service for php-fpm
         fastcgi_pass php-fpm:9000;
         fastcgi_index index.php;
         include fastcgi_params;
@@ -136,7 +139,6 @@ server {
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param HTTP_PROXY "";
 
-        # Don't allow browser caching of dynamically generated content
         add_header Last-Modified $date_gmt;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
         if_modified_since off;
@@ -151,12 +153,11 @@ server {
         fastcgi_read_timeout 300;
     }
 }
-
 ```
 
 ## Installing Extensions
 
-This image is based off the official Docker PHP FPM image (Alpine Linux). Therefore you can use all of the tools to install PHP extensions. To install an extension, you have to switch to the `root` user.
+This image is based off the [official Docker PHP FPM image](https://hub.docker.com/_/php) (Alpine Linux). Therefore you can use all of the tools to install PHP extensions. To install an extension, you have to switch to the `root` user. This example switches to the `root` user to install the [`sockets` extension](https://www.php.net/manual/en/book.sockets.php) for PHP 7.4. Note that it switches back to `www-data` after installation:
 
 ```dockerfile
 FROM craftcms/php-fpm:7.4


### PR DESCRIPTION
- Adds links to a few resources.
- Various edits for brevity and clarity.
- Boldly relabels `queue` service to `console` in Docker Compose example.
- Spells out changes from NYstudio107 nginx config, further reducing inline comments.