### PR TITLE
Add imagemagick to apk package install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex && \
         freetype-dev \
         libpng-dev \
         libjpeg-turbo-dev \
+        imagemagick \
         imagemagick-dev \
         imagemagick-libs && \
     docker-php-ext-configure gd && \


### PR DESCRIPTION
Without the `imagemagick` package installed everything appears to work fine until you try to upload an image and are greeted with the `... does not appear to be an image` error. After inspecting PHP info, Imagick seems to be installed however this line stands out:-
```
ImageMagick number of supported formats:  => 0
```
After installing the `imagemagick` package and restarting the container:-
```
ImageMagick number of supported formats:  => 234
```
... and image uploads are working.