### PR TITLE
Add mariadb-connector-c package to supported PHP-FPM dev versions

### DIFF
--- a/7.4/dev.Dockerfile
+++ b/7.4/dev.Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex && \
     g++ \
     make \
     mysql-client \
+    mariadb-connector-c \
     postgresql-client \
     git \
     && \

--- a/8.0/dev.Dockerfile
+++ b/8.0/dev.Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex && \
     g++ \
     make \
     mysql-client \
+    mariadb-connector-c \
     postgresql-client \
     git \
     && \


### PR DESCRIPTION
### Description

For those that provision MySQL 8 when using the Craft CMS php-fpm dev images, you will likely find Craft's native backup/restore options will fail because mysqldump throws the following error for MySQL 8 setups.

> mysqldump: Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory

The reason for this is because the mysql-client tools package from Alpine has been built against MariaDB not MySQL. MariaDB itself does not ship support for `caching_sha2_password` by default. In order to have this support within the PHP FPM container, the additional package of `mariadb-c-connector` must be installed for the required plugin file that is referenced to be installed to `/usr/lib/mariadb/plugin/`.

Those that use MySQL 8 provisioned with the newer caching_sha2_password option (rather than `native_password`) with the PHP FPM dev images will encounter mysqldump being broken unless the MySQL database allows `native_password`, which is more of a workaround for this situation.

All versions of PHP 7.3 and 7.4 support `caching_sha2_password` and PHP 7.1.16 and PHP 7.2.4+ should also support this, which I believe should be met by the docker images if PHP 7.1 and 7.2 is used. PHP 7.0 has no support for it, so I have not added the package to that image.

https://www.php.net/manual/en/mysqli.requirements.php

To allow those that use MySQL 8 containers to have a working out of the box experience, please consider allowing this additional package in the dev images :)!

Thanks!

### Related issues

https://github.com/craftcms/docker/issues/19