### PR TITLE
Allow txt files also be handled by craft for SEO

### DIFF
--- a/nginx/craftcms/general.conf
+++ b/nginx/craftcms/general.conf
@@ -11,7 +11,7 @@ location = /robots.txt {
 }
 
 # assets, media
-location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
+location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|txt)$ {
     try_files $uri /index.php?$query_string;
     expires    7d;
     access_log off;


### PR DESCRIPTION
txt files should also be considered by craft for the SEO plugins. So a robots.txt could be generated.

### Description



