### PR TITLE
Remove expose port 9003 for Xdebug

### DIFF
--- a/7.0/dev.Dockerfile
+++ b/7.0/dev.Dockerfile
@@ -28,9 +28,6 @@ RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir
 # downgrade composer to version 1
 RUN set -ex && composer self-update --1
 
-# expose the xdebug port
-EXPOSE 9003
-
 # expose additional ports for node
 EXPOSE 3000 3001
 

--- a/7.1/dev.Dockerfile
+++ b/7.1/dev.Dockerfile
@@ -35,9 +35,6 @@ RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir
 # downgrade composer to version 1
 RUN set -ex && composer self-update --1
 
-# expose the xdebug port
-EXPOSE 9003
-
 # expose additional ports for node
 EXPOSE 3000 3001
 

--- a/7.2/dev.Dockerfile
+++ b/7.2/dev.Dockerfile
@@ -32,9 +32,6 @@ RUN set -ex && \
 # install composer
 RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-# expose the xdebug port
-EXPOSE 9003
-
 # expose additional ports for node
 EXPOSE 3000 3001
 

--- a/7.3/dev.Dockerfile
+++ b/7.3/dev.Dockerfile
@@ -32,9 +32,6 @@ RUN set -ex && \
 # install composer
 RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-# expose the xdebug port
-EXPOSE 9003
-
 # expose additional ports for node
 EXPOSE 3000 3001
 

--- a/7.4/dev.Dockerfile
+++ b/7.4/dev.Dockerfile
@@ -32,9 +32,6 @@ RUN set -ex && \
 # install composer
 RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-# expose the xdebug port
-EXPOSE 9003
-
 # expose additional ports for node
 EXPOSE 3000 3001
 

--- a/8.0/dev.Dockerfile
+++ b/8.0/dev.Dockerfile
@@ -31,9 +31,6 @@ RUN set -ex && \
 # install composer
 RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-# expose the xdebug port
-EXPOSE 9003
-
 # expose additional ports for node
 EXPOSE 3000 3001
 


### PR DESCRIPTION
You don't need to expose port `9003` for Xdebug (version 2.x or 3.x), because it's Xdebug that reaches out and connects to the client/IDE and not the other way around.

Resolves https://github.com/craftcms/docker/issues/30