### PR TITLE
Fix iconv (again)

### DIFF
--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,6 +1,9 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.13 AS iconv-build
+RUN apk add --no-cache gnu-libiconv
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine
 
 # setup general options for environment variables
@@ -73,6 +76,9 @@ RUN set -ex && \
     g++ \
     make \
     imagemagick-dev
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
 
 # https://github.com/docker-library/php/issues/1121
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,6 +1,9 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.13 AS iconv-build
+RUN apk add --no-cache gnu-libiconv
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine
 
 # setup general options for environment variables
@@ -73,6 +76,9 @@ RUN set -ex && \
     g++ \
     make \
     imagemagick-dev
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
 
 # https://github.com/docker-library/php/issues/1121
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,6 +1,9 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.13 AS iconv-build
+RUN apk add --no-cache gnu-libiconv
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine
 
 # setup general options for environment variables
@@ -41,7 +44,6 @@ RUN set -ex && \
     g++ \
     make \
     freetype \
-    # gnu-libiconv=1.15-r3 \
     libzip-dev \
     libpng \
     libjpeg-turbo \
@@ -74,6 +76,9 @@ RUN set -ex && \
     g++ \
     make \
     imagemagick-dev
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
 
 # https://github.com/docker-library/php/issues/1121
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -34,6 +34,9 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 RUN set -ex && \
+    # https://github.com/craftcms/docker/issues/16
+    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
+
     apk --no-cache add \
     postgresql-client \
     postgresql-dev \
@@ -45,7 +48,6 @@ RUN set -ex && \
     libpng \
     libjpeg-turbo \
     freetype-dev \
-    gnu-libiconv=1.15-r3 \
     libpng-dev \
     libjpeg-turbo-dev \
     libxml2-dev \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,6 +1,9 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.13 AS iconv-build
+RUN apk add --no-cache gnu-libiconv
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine
 
 # setup general options for environment variables
@@ -34,9 +37,6 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 RUN set -ex && \
-    # https://github.com/craftcms/docker/issues/16
-    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
-
     apk --no-cache add \
     postgresql-client \
     postgresql-dev \
@@ -76,6 +76,9 @@ RUN set -ex && \
     g++ \
     make \
     imagemagick-dev
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
 
 # https://github.com/docker-library/php/issues/1121
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -34,6 +34,9 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 RUN set -ex && \
+    # https://github.com/craftcms/docker/issues/16
+    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
+
     apk --no-cache add \
     postgresql-client \
     postgresql-dev \
@@ -45,7 +48,6 @@ RUN set -ex && \
     libpng \
     libjpeg-turbo \
     freetype-dev \
-    gnu-libiconv=1.15-r3 \
     libpng-dev \
     libjpeg-turbo-dev \
     libxml2-dev \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,6 +1,9 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.13 AS iconv-build
+RUN apk add --no-cache gnu-libiconv
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine
 
 # setup general options for environment variables
@@ -34,9 +37,6 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 RUN set -ex && \
-    # https://github.com/craftcms/docker/issues/16
-    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
-
     apk --no-cache add \
     postgresql-client \
     postgresql-dev \
@@ -76,6 +76,9 @@ RUN set -ex && \
     g++ \
     make \
     imagemagick-dev
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
 
 # https://github.com/docker-library/php/issues/1121
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,6 +1,9 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.13 AS iconv-build
+RUN apk add --no-cache gnu-libiconv
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine
 
 # setup general options for environment variables
@@ -34,9 +37,6 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 RUN set -ex && \
-    # https://github.com/craftcms/docker/issues/16
-    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
-
     apk --no-cache add \
     postgresql-client \
     postgresql-dev \
@@ -44,6 +44,7 @@ RUN set -ex && \
     g++ \
     make \
     freetype \
+    gnu-libiconv \
     libzip-dev \
     libpng \
     libjpeg-turbo \
@@ -72,6 +73,9 @@ RUN set -ex && \
     autoconf \
     g++ \
     make
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
 
 # https://github.com/docker-library/php/issues/1121
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -34,6 +34,9 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 RUN set -ex && \
+    # https://github.com/craftcms/docker/issues/16
+    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ gnu-libiconv=1.15-r3 && \
+
     apk --no-cache add \
     postgresql-client \
     postgresql-dev \
@@ -41,7 +44,6 @@ RUN set -ex && \
     g++ \
     make \
     freetype \
-    gnu-libiconv=1.15-r3 \
     libzip-dev \
     libpng \
     libjpeg-turbo \


### PR DESCRIPTION
### Description
`gnu-libiconv=1.15-r3` is no longer installable with latest Alpine (3.14).

### Related issues
https://github.com/docker-library/php/issues/240