### PR TITLE
Add craft server check

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -132,6 +132,15 @@ COPY blackfire-install.sh /tmp/blackfire-install.sh
 # run the installation script
 RUN set -ex && sh /tmp/blackfire-install.sh && rm -rf /tmp/blackfire*
 
+# run server check
+RUN set -ex \
+    && export CRAFT_STRICT_SERVER_CHECK=1 \
+    && apk add --no-cache --virtual .server-check-deps \
+    bash \
+    curl \
+    && curl -Lsf https://raw.githubusercontent.com/craftcms/server-check/HEAD/check.sh | bash \
+    && apk del --no-network .server-check-deps
+
 # make the directories and set permissions
 RUN mkdir -p /app
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -130,6 +130,15 @@ COPY blackfire-install.sh /tmp/blackfire-install.sh
 # run the installation script
 RUN set -ex && sh /tmp/blackfire-install.sh && rm -rf /tmp/blackfire*
 
+# run server check
+RUN set -ex \
+    && export CRAFT_STRICT_SERVER_CHECK=1 \
+    && apk add --no-cache --virtual .server-check-deps \
+    bash \
+    curl \
+    && curl -Lsf https://raw.githubusercontent.com/craftcms/server-check/HEAD/check.sh | bash \
+    && apk del --no-network .server-check-deps
+
 # make the directories and set permissions
 RUN mkdir -p /app
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -130,6 +130,15 @@ COPY blackfire-install.sh /tmp/blackfire-install.sh
 # run the installation script
 RUN set -ex && sh /tmp/blackfire-install.sh && rm -rf /tmp/blackfire*
 
+# run server check
+RUN set -ex \
+    && export CRAFT_STRICT_SERVER_CHECK=1 \
+    && apk add --no-cache --virtual .server-check-deps \
+    bash \
+    curl \
+    && curl -Lsf https://raw.githubusercontent.com/craftcms/server-check/HEAD/check.sh | bash \
+    && apk del --no-network .server-check-deps
+
 # make the directories and set permissions
 RUN mkdir -p /app
 

--- a/8.1-rc/Dockerfile
+++ b/8.1-rc/Dockerfile
@@ -130,6 +130,15 @@ COPY blackfire-install.sh /tmp/blackfire-install.sh
 # run the installation script
 RUN set -ex && sh /tmp/blackfire-install.sh && rm -rf /tmp/blackfire*
 
+# run server check
+RUN set -ex \
+    && export CRAFT_STRICT_SERVER_CHECK=1 \
+    && apk add --no-cache --virtual .server-check-deps \
+    bash \
+    curl \
+    && curl -Lsf https://raw.githubusercontent.com/craftcms/server-check/HEAD/check.sh | bash \
+    && apk del --no-network .server-check-deps
+
 # make the directories and set permissions
 RUN mkdir -p /app
 


### PR DESCRIPTION
Note: I'm intentionally running the server check _after_ the runtime-deps/cleanup stuff, as if our runtime-deps don't end up installed properly, we want the check to fail.