### PR TITLE
Fix permission issue for nginx logs

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -16,7 +16,7 @@ RUN touch /run/nginx.pid
 RUN touch /run/supervisord.pid
 RUN chown www-data /run/nginx.pid
 RUN chown www-data /run/supervisord.pid
-RUN chown -R www-data:www-data /var/lib/nginx/logs/
+RUN chown -R www-data:www-data /var/lib/nginx/
 USER www-data
 
 EXPOSE 8080


### PR DESCRIPTION
We are seeing the following error message when running a container:
`nginx: [alert] could not open error log file: open() "/var/lib/nginx/logs/error.log" failed (13: Permission denied)`

Seems like we're using default log paths for nginx but the permissions seem off.
We are running `nginx` with the user `www-data` whilst the `/var/lib/nginx` folder is still owned by the `nginx` user.

![image](https://user-images.githubusercontent.com/668419/221622274-de23d529-729b-481f-b114-d6bca054c7d4.png)
![image](https://user-images.githubusercontent.com/668419/221620696-ca9d21c1-ed79-40d1-9478-d9044abd3f12.png)
![image](https://user-images.githubusercontent.com/668419/221620727-7217a44a-cd4c-4b60-85e4-1bf0643c2019.png)
