### PR TITLE
Upgrading Alpine version to `3.18` in the PHP `8.1` image

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.13 AS iconv-build
 RUN apk upgrade --no-cache \
     && apk add --no-cache gnu-libiconv
 
-FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.16
+FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.18
 
 # setup general options for environment variables
 ARG PHP_MEMORY_LIMIT_ARG="256M"


### PR DESCRIPTION
### Description

Upgrading Alpine version to `3.18` in the PHP `8.1` image.

### Related issues

Please forgive me for not opening an issue first, I don't know if that's a requirement for the procedure of requesting an update in this repo.

### Purpose

The update here is being introduced to allow for the AWS CLI v2 to be installed in the image without having to compile from source:

```bash
$ docker run --rm --entrypoint ash php:8.1-fpm-alpine3.16 -c 'apk add --no-cache aws-cli && aws --version'
...
aws-cli/1.22.81 Python/3.10.12 Linux/5.15.49-linuxkit-pr botocore/1.21.49
```

```bash
$ docker run --rm --entrypoint ash php:8.1-fpm-alpine3.18 -c 'apk add --no-cache aws-cli && aws --version'
...
aws-cli/2.13.5 Python/3.11.4 Linux/5.15.49-linuxkit-pr source/aarch64.alpine.3 prompt/off
```