### PR TITLE
Add support for PHP 8.3

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.2", "8.1", "8.0"]
+        php: ["8.3", "8.2", "8.1", "8.0"]
         type: ["php-fpm", "cli"]
         include:
           - type: php-fpm
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.2", "8.1", "8.0"]
+        php: ["8.3", "8.2", "8.1", "8.0"]
     steps:
       - name: Set env
         run: |

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,0 +1,132 @@
+ARG PHP_VERSION
+ARG PROJECT_TYPE
+
+FROM alpine:3.13 AS iconv-build
+RUN apk upgrade --no-cache \
+    && apk add --no-cache gnu-libiconv
+
+FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.19
+
+# setup general options for environment variables
+ARG PHP_MEMORY_LIMIT_ARG="256M"
+ENV PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT_ARG}
+ARG PHP_MAX_EXECUTION_TIME_ARG="120"
+ENV PHP_MAX_EXECUTION_TIME=${PHP_MAX_EXECUTION_TIME_ARG}
+ARG PHP_UPLOAD_MAX_FILESIZE_ARG="20M"
+ENV PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE_ARG}
+ARG PHP_MAX_INPUT_VARS_ARG="1000"
+ENV PHP_MAX_INPUT_VARS=${PHP_MAX_INPUT_VARS_ARG}
+ARG PHP_POST_MAX_SIZE_ARG="8M"
+ENV PHP_POST_MAX_SIZE=${PHP_POST_MAX_SIZE_ARG}
+
+# setup opcache for environment variables
+ARG PHP_OPCACHE_ENABLE_ARG="1"
+ARG PHP_OPCACHE_REVALIDATE_FREQ_ARG="0"
+ARG PHP_OPCACHE_VALIDATE_TIMESTAMPS_ARG="0"
+ARG PHP_OPCACHE_MAX_ACCELERATED_FILES_ARG="10000"
+ARG PHP_OPCACHE_MEMORY_CONSUMPTION_ARG="128"
+ARG PHP_OPCACHE_MAX_WASTED_PERCENTAGE_ARG="10"
+ARG PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG="16"
+ARG PHP_OPCACHE_FAST_SHUTDOWN_ARG="1"
+ENV PHP_OPCACHE_ENABLE=$PHP_OPCACHE_ENABLE_ARG
+ENV PHP_OPCACHE_REVALIDATE_FREQ=$PHP_OPCACHE_REVALIDATE_FREQ_ARG
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=$PHP_OPCACHE_VALIDATE_TIMESTAMPS_ARG
+ENV PHP_OPCACHE_MAX_ACCELERATED_FILES=$PHP_OPCACHE_MAX_ACCELERATED_FILES_ARG
+ENV PHP_OPCACHE_MEMORY_CONSUMPTION=$PHP_OPCACHE_MEMORY_CONSUMPTION_ARG
+ENV PHP_OPCACHE_MAX_WASTED_PERCENTAGE=$PHP_OPCACHE_MAX_WASTED_PERCENTAGE_ARG
+ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
+ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
+
+# MozJPEG
+ENV MOZJPEG_VERSION="3.3.1"
+ENV MOZJPEG_BUILD_DEPS \
+    autoconf \
+    automake \
+    build-base \
+    libtool \
+    nasm \
+    pkgconf \
+    tar
+
+RUN set -ex \
+    && apk upgrade --no-cache \
+    && apk add --no-cache --virtual .build-deps \
+    $PHPIZE_DEPS \
+    $MOZJPEG_BUILD_DEPS \
+    freetype-dev \
+    icu-dev \
+    icu-data-full \
+    libwebp-dev \
+    imagemagick-dev \
+    libjpeg-turbo-dev \
+    libpng-dev \
+    libxml2-dev \
+    libzip-dev \
+    postgresql-dev \
+    && apk add --no-cache \
+    gifsicle \
+    imagemagick \
+    jpegoptim \
+    libjpeg-turbo-utils \
+    libwebp-tools \
+    optipng \
+    pngquant \
+    && docker-php-ext-configure gd \
+    --with-freetype \
+    --with-jpeg \
+    --with-webp \
+    && docker-php-ext-install -j$(nproc) \
+    bcmath \
+    gd \
+    intl \
+    opcache \
+    pdo \
+    pdo_mysql \
+    pdo_pgsql \
+    soap \
+    zip \
+    && pecl install \
+    imagick \
+    redis \
+    && docker-php-ext-enable \
+    imagick \
+    redis
+
+# https://github.com/craftcms/docker/issues/16
+COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
+
+# https://github.com/docker-library/php/issues/1121
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
+
+# MozJPEG
+WORKDIR /tmp
+ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
+RUN set -ex \
+    && tar -xzf v${MOZJPEG_VERSION}.tar.gz \
+    && cd ./mozjpeg-${MOZJPEG_VERSION} \
+    && autoreconf -fiv \
+    && ./configure --with-jpeg8 \
+    && make \
+    && make install
+
+RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran
+RUN ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
+
+# Cleanup
+RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
+    | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+    | sort -u \
+    | xargs -r apk info --installed \
+    | sort -u)" \
+    && apk add --no-cache --virtual .runtime-deps $RUNTIME_DEPS \
+    && apk del --no-network .build-deps \
+    && rm -rf /tmp/*
+
+# copy custom.ini settings
+COPY craft-cms.ini /usr/local/etc/php/conf.d/
+
+# run container as the www-data user
+USER www-data
+
+# set the working directory for convenience
+WORKDIR /app

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -86,11 +86,15 @@ RUN set -ex \
     soap \
     zip \
     && pecl install \
-    imagick \
     redis \
     && docker-php-ext-enable \
-    imagick \
     redis
+
+# Install imagick from master because there's no tagged release in PECL yet with fixes for PHP 8.3
+# https://github.com/Imagick/imagick/issues/640
+# Workaround from https://github.com/yiisoft/yii2-docker/compare/324f7e8a36b394d637f1b327d474597b8a49f7de...master
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions imagick/imagick@master
 
 # https://github.com/craftcms/docker/issues/16
 COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -38,10 +38,11 @@ ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
 # MozJPEG
-ENV MOZJPEG_VERSION="3.3.1"
+ENV MOZJPEG_VERSION="4.1.1"
 ENV MOZJPEG_BUILD_DEPS \
     autoconf \
     automake \
+    cmake \
     build-base \
     libtool \
     nasm \
@@ -70,7 +71,9 @@ RUN set -ex \
     libjpeg-turbo-utils \
     libwebp-tools \
     optipng \
+    libpng-static \
     pngquant \
+    zlib-static \
     && docker-php-ext-configure gd \
     --with-freetype \
     --with-jpeg \
@@ -108,9 +111,7 @@ ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
 RUN set -ex \
     && tar -xzf v${MOZJPEG_VERSION}.tar.gz \
     && cd ./mozjpeg-${MOZJPEG_VERSION} \
-    && autoreconf -fiv \
-    && ./configure --with-jpeg8 \
-    && make \
+    && cmake -DCMAKE_BUILD_TYPE=Release . \
     && make install
 
 RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran

--- a/8.3/craft-cms-xdebug.ini
+++ b/8.3/craft-cms-xdebug.ini
@@ -1,0 +1,1 @@
+xdebug.mode=develop,debug

--- a/8.3/craft-cms.ini
+++ b/8.3/craft-cms.ini
@@ -1,0 +1,14 @@
+memory_limit=${PHP_MEMORY_LIMIT}
+max_execution_time=${PHP_MAX_EXECUTION_TIME}
+upload_max_filesize=${PHP_UPLOAD_MAX_FILESIZE}
+max_input_vars=${PHP_MAX_INPUT_VARS}
+post_max_size=${PHP_POST_MAX_SIZE}
+[opcache]
+opcache.enable=${PHP_OPCACHE_ENABLE}
+opcache.revalidate_freq=${PHP_OPCACHE_REVALIDATE_FREQ}
+opcache.validate_timestamps=${PHP_OPCACHE_VALIDATE_TIMESTAMPS}
+opcache.max_accelerated_files=${PHP_OPCACHE_MAX_ACCELERATED_FILES}
+opcache.memory_consumption=${PHP_OPCACHE_MEMORY_CONSUMPTION}
+opcache.max_wasted_percentage=${PHP_OPCACHE_MAX_WASTED_PERCENTAGE}
+opcache.interned_strings_buffer=${PHP_OPCACHE_INTERNED_STRINGS_BUFFER}
+opcache.fast_shutdown=${PHP_OPCACHE_FAST_SHUTDOWN}

--- a/8.3/dev.Dockerfile
+++ b/8.3/dev.Dockerfile
@@ -1,0 +1,33 @@
+ARG PHP_VERSION
+ARG PROJECT_TYPE
+FROM craftcms/${PROJECT_TYPE}:${PHP_VERSION}
+
+# disable opcache
+ENV PHP_OPCACHE_ENABLE=0
+
+USER root
+
+COPY craft-cms-xdebug.ini /usr/local/etc/php/conf.d/
+
+RUN set -ex \
+    && apk upgrade --no-cache \
+    && apk --no-cache add --virtual .build-deps $PHPIZE_DEPS \
+    && apk --no-cache add \
+    git \
+    mariadb-connector-c \
+    mysql-client \
+    nodejs \
+    npm \
+    postgresql-client \
+    linux-headers \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del --no-network .build-deps
+
+# install composer
+RUN set -ex && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+
+# expose additional ports for node
+EXPOSE 3000 3001
+
+USER www-data

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 .PHONY: build snyk
 
-LOCAL_PHP_VERSION ?= 8.2
+LOCAL_PHP_VERSION ?= 8.3
 
 build: all-cli all-cli-dev all-php-fpm all-php-fpm-dev all-nginx all-nginx-dev
 snyk: snyk-all-cli snyk-all-cli-dev snyk-all-php-fpm snyk-all-php-fpm-dev snyk-all-nginx snyk-all-nginx-dev
 
 all-cli:
+	docker buildx build --load --platform linux/amd64 --builder all-platforms \
+		--build-arg PHP_VERSION=8.3 \
+		--build-arg PROJECT_TYPE=cli \
+		-t craftcms/cli:8.3 8.3
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
 		--build-arg PHP_VERSION=8.2 \
 		--build-arg PROJECT_TYPE=cli \
@@ -20,6 +24,11 @@ all-cli:
 		-t craftcms/cli:8.0 8.0
 
 all-cli-dev:
+	docker buildx build --load --platform linux/amd64 --builder all-platforms \
+		-f 8.3/dev.Dockerfile \
+		--build-arg PHP_VERSION=8.3 \
+		--build-arg PROJECT_TYPE=cli \
+		-t craftcms/cli:8.3-dev 8.3
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
 		-f 8.2/dev.Dockerfile \
 		--build-arg PHP_VERSION=8.2 \
@@ -38,6 +47,10 @@ all-cli-dev:
 
 all-php-fpm:
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
+		--build-arg PHP_VERSION=8.3 \
+		--build-arg PROJECT_TYPE=fpm \
+		-t craftcms/php-fpm:8.3 8.3
+	docker buildx build --load --platform linux/amd64 --builder all-platforms \
 		--build-arg PHP_VERSION=8.2 \
 		--build-arg PROJECT_TYPE=fpm \
 		-t craftcms/php-fpm:8.2 8.2
@@ -51,6 +64,11 @@ all-php-fpm:
 		-t craftcms/php-fpm:8.0 8.0
 
 all-php-fpm-dev:
+	docker buildx build --load --platform linux/amd64 --builder all-platforms \
+		-f 8.3/dev.Dockerfile \
+		--build-arg PHP_VERSION=8.3 \
+		--build-arg PROJECT_TYPE=php-fpm \
+		-t craftcms/php-fpm:8.3-dev 8.3
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
 		-f 8.2/dev.Dockerfile \
 		--build-arg PHP_VERSION=8.2 \
@@ -69,6 +87,9 @@ all-php-fpm-dev:
 
 all-nginx:
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
+		--build-arg PHP_VERSION=8.3 \
+		-t craftcms/nginx:8.3 nginx
+	docker buildx build --load --platform linux/amd64 --builder all-platforms \
 		--build-arg PHP_VERSION=8.2 \
 		-t craftcms/nginx:8.2 nginx
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
@@ -79,6 +100,10 @@ all-nginx:
 		-t craftcms/nginx:8.0 nginx
 
 all-nginx-dev:
+	docker buildx build --load --platform linux/amd64 --builder all-platforms \
+		--build-arg PHP_VERSION=8.3 \
+		--build-arg NGINX_CONF=dev.default.conf \
+		-t craftcms/nginx:8.3-dev nginx
 	docker buildx build --load --platform linux/amd64 --builder all-platforms \
 		--build-arg PHP_VERSION=8.2 \
 		--build-arg NGINX_CONF=dev.default.conf \
@@ -152,36 +177,42 @@ snyk-local:
 
 snyk-all-cli:
 	snyk container test \
+	craftcms/cli:8.3 \
 	craftcms/cli:8.2 \
 	craftcms/cli:8.1 \
 	craftcms/cli:8.0
 
 snyk-all-cli-dev:
 	snyk container test \
+	craftcms/cli:8.3-dev \
 	craftcms/cli:8.2-dev \
 	craftcms/cli:8.1-dev \
 	craftcms/cli:8.0-dev
 
 snyk-all-php-fpm:
 	snyk container test \
+	craftcms/php-fpm:8.3 \
 	craftcms/php-fpm:8.2 \
 	craftcms/php-fpm:8.1 \
 	craftcms/php-fpm:8.0
 
 snyk-all-php-fpm-dev:
 	snyk container test \
+	craftcms/php-fpm:8.3-dev \
 	craftcms/php-fpm:8.2-dev \
 	craftcms/php-fpm:8.1-dev \
 	craftcms/php-fpm:8.0-dev
 
 snyk-all-nginx:
 	snyk container test \
+	craftcms/nginx:8.3 \
 	craftcms/nginx:8.2 \
 	craftcms/nginx:8.1 \
 	craftcms/nginx:8.0
 
 snyk-all-nginx-dev:
 	snyk container test \
+	craftcms/nginx:8.3-dev \
 	craftcms/nginx:8.2-dev \
 	craftcms/nginx:8.1-dev \
 	craftcms/nginx:8.0-dev

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ These images are provided as a starting point for your Docker-based Craft CMS de
 
 ## Images
 
-There are three main "types" of images provided for different types of applications; `php-fpm`, `nginx`, and `cli`. Each image allows the developer to select a PHP version (e.g. `craftcms/nginx:8.2`).
+There are three main "types" of images provided for different types of applications; `php-fpm`, `nginx`, and `cli`. Each image allows the developer to select a PHP version (e.g. `craftcms/nginx:8.3`).
 
-Each image and PHP version also provides a `-dev` variant which has Xdebug installed and is useful for local development (e.g. `craftcms/php-fpm:8.2-dev`), as well as database tools for creating and restoring backups. Images that do not include `-dev` are considered production.
+Each image and PHP version also provides a `-dev` variant which has Xdebug installed and is useful for local development (e.g. `craftcms/php-fpm:8.3-dev`), as well as database tools for creating and restoring backups. Images that do not include `-dev` are considered production.
 
 > Note: you are not required to use `-dev` images for local development, they are provided with Xdebug and to make debugging easier.
 
@@ -22,6 +22,8 @@ The `php-fpm` image is provided as the base image (and is also used for the `ngi
 
 | Image                      | Use | Environment   | Status            |
 | -------------------------- | --- | ------------- | ----------------- |
+| `craftcms/php-fpm:8.3`     | web | `production`  |                   |
+| `craftcms/php-fpm:8.3-dev` | web | `development` |                   |
 | `craftcms/php-fpm:8.2`     | web | `production`  |                   |
 | `craftcms/php-fpm:8.2-dev` | web | `development` |                   |
 | `craftcms/php-fpm:8.1`     | web | `production`  |                   |
@@ -47,6 +49,8 @@ The `nginx` image is used for a typical installation and includes an Nginx serve
 
 | Image                    | Use | Environment   | Status            |
 | ------------------------ | --- | ------------- | ----------------- |
+| `craftcms/nginx:8.3`     | web | `production`  |                   |
+| `craftcms/nginx:8.3-dev` | web | `development` |                   |
 | `craftcms/nginx:8.2`     | web | `production`  |                   |
 | `craftcms/nginx:8.2-dev` | web | `development` |                   |
 | `craftcms/nginx:8.1`     | web | `production`  |                   |
@@ -72,6 +76,8 @@ The image type `cli` which is used to run queues, migrations, etc. and the image
 
 | Image                  | Use | Environment   | Status            |
 | ---------------------- | --- | ------------- | ----------------- |
+| `craftcms/cli:8.3`     | web | `production`  |                   |
+| `craftcms/cli:8.3-dev` | web | `development` |                   |
 | `craftcms/cli:8.2`     | web | `production`  |                   |
 | `craftcms/cli:8.2-dev` | web | `development` |                   |
 | `craftcms/cli:8.1`     | web | `production`  |                   |
@@ -102,7 +108,7 @@ COPY composer.json composer.json
 COPY composer.lock composer.lock
 RUN composer install --ignore-platform-reqs --no-interaction --prefer-dist
 
-FROM craftcms/php-fpm:8.2
+FROM craftcms/php-fpm:8.3
 
 # the user is `www-data`, so we copy the files using the user and group
 COPY --chown=www-data:www-data --from=vendor /app/vendor/ /app/vendor/
@@ -120,7 +126,7 @@ COPY composer.json composer.json
 COPY composer.lock composer.lock
 RUN composer install --ignore-platform-reqs --no-interaction --prefer-dist
 
-FROM craftcms/nginx:8.2
+FROM craftcms/nginx:8.3
 
 # switch to the root user to install mysql tools
 USER root
@@ -151,7 +157,7 @@ We recommend running Docker locally if you’re shipping your project to a Docke
 version: "3.6"
 services:
   console:
-    image: craftcms/cli:8.2-dev
+    image: craftcms/cli:8.3-dev
     env_file: .env
     environment:
       XDEBUG_CONFIG: client_host=host.docker.internal
@@ -165,7 +171,7 @@ services:
     command: php craft queue/listen
 
   web:
-    image: craftcms/nginx:8.2-dev
+    image: craftcms/nginx:8.3-dev
     ports:
       - 8080:8080
     env_file: .env
@@ -214,10 +220,10 @@ This can be done via environment variable: `XDEBUG_CONFIG=client_host=host.docke
 
 ## Installing Extensions
 
-This image is based off the [official Docker PHP FPM image](https://hub.docker.com/_/php) (Alpine Linux). Therefore you can use all of the tools to install PHP extensions. To install an extension, you have to switch to the `root` user. This example switches to the `root` user to install the [`sockets` extension](https://www.php.net/manual/en/book.sockets.php) for PHP 8.2. Note that it switches back to `www-data` after installation:
+This image is based off the [official Docker PHP FPM image](https://hub.docker.com/_/php) (Alpine Linux). Therefore you can use all of the tools to install PHP extensions. To install an extension, you have to switch to the `root` user. This example switches to the `root` user to install the [`sockets` extension](https://www.php.net/manual/en/book.sockets.php) for PHP 8.3. Note that it switches back to `www-data` after installation:
 
 ```dockerfile
-FROM craftcms/php-fpm:8.2
+FROM craftcms/php-fpm:8.3
 
 # switch to the root user
 USER root
@@ -239,7 +245,7 @@ In this example, we’re setting the PHP memory limit to `512M` rather than the 
 version: "3.6"
 services:
   php-fpm:
-    image: craftcms/php-fpm:8.2-dev
+    image: craftcms/php-fpm:8.3-dev
     volumes:
       - .:/app
     env_file: .env


### PR DESCRIPTION
### Description


PHP 8.2 will stop to be actively supported in just 7 months. Let's get ready for that by supporting PHP 8.3 which was released in November 2023?

![Screenshot 2024-04-09 at 23 51 30@2x](https://github.com/craftcms/docker/assets/1352979/f9d5ef3b-5fc0-42b6-b8aa-7cd9dd3a3e20)


**Important changes:**
- Started from a copy from the 8.2 folder
- Only issue was with **Imagick**  that throws an error during build. There are issues/PR's open in the imagick repo but no clear timeline about a release that contains the fix. It seems to be fixed in the develop/master branch though but not released on PECL. The project seems to be a bit abandoned as well. I followed the fix that Yii framework had to do [here](https://github.com/yiisoft/yii2-docker/compare/324f7e8a36b394d637f1b327d474597b8a49f7de...master). See [line 96 of the Dockerfile](https://github.com/craftcms/docker/pull/92/files#diff-8b491f6e4f3f2ceb0a569e603512aa24feaa336f70aa34536b9ab0639427e6b3R96-R100)
- Bumped mozjpeg version from 3.3.1 to 4.1.1. They switched to use `cmake` to build, so it required a change in Dockerfile.


### Related issues
#90 
