### PR TITLE
fix: #94 Moving cleanup to dramatically reduce image size

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
-FROM alpine:3.19 AS mozjpeg-build
+FROM alpine:3.18 AS mozjpeg-build
 ENV MOZJPEG_VERSION="3.3.1"
 
 ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
@@ -96,16 +96,8 @@ RUN set -ex \
     redis \
     && docker-php-ext-enable \
     imagick \
-    redis
-
-# MozJPEG
-COPY --from=mozjpeg-build /opt/mozjpeg/bin/jpegtran /opt/mozjpeg/bin/jpegtran
-COPY --from=mozjpeg-build /opt/mozjpeg/bin/cjpeg /opt/mozjpeg/bin/cjpeg
-RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran \
-    && ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
-
-# Cleanup
-RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
+    redis \
+    && RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
     | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
     | sort -u \
     | xargs -r apk info --installed \
@@ -113,6 +105,12 @@ RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
     && apk add --no-cache --virtual .runtime-deps $RUNTIME_DEPS \
     && apk del --no-network .build-deps \
     && rm -rf /tmp/*
+
+# MozJPEG
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/jpegtran /opt/mozjpeg/bin/jpegtran
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/cjpeg /opt/mozjpeg/bin/cjpeg
+RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran \
+    && ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
 
 # copy custom.ini settings
 COPY craft-cms.ini /usr/local/etc/php/conf.d/

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,10 +1,6 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
-FROM alpine:3.13 AS iconv-build
-RUN apk upgrade --no-cache \
-    && apk add --no-cache gnu-libiconv
-
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.18
 
 # setup general options for environment variables
@@ -71,6 +67,7 @@ RUN set -ex \
     libwebp-tools \
     optipng \
     pngquant \
+    gnu-libiconv \
     && docker-php-ext-configure gd \
     --with-freetype \
     --with-jpeg \
@@ -91,12 +88,6 @@ RUN set -ex \
     && docker-php-ext-enable \
     imagick \
     redis
-
-# https://github.com/craftcms/docker/issues/16
-COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
-
-# https://github.com/docker-library/php/issues/1121
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 # MozJPEG
 WORKDIR /tmp

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,6 +1,27 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.19 AS mozjpeg-build
+ENV MOZJPEG_VERSION="3.3.1"
+
+ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
+RUN set -ex \
+  && apk upgrade --no-cache \
+  && apk add --no-cache --virtual .build-deps \
+    autoconf \
+    automake \
+    build-base \
+    libtool \
+    nasm \
+    pkgconf \
+    tar \
+  && tar -xzf v${MOZJPEG_VERSION}.tar.gz \
+  && cd ./mozjpeg-${MOZJPEG_VERSION} \
+  && autoreconf -fiv \
+  && ./configure --with-jpeg8 \
+  && make \
+  && make install
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.18
 
 # setup general options for environment variables
@@ -33,22 +54,10 @@ ENV PHP_OPCACHE_MAX_WASTED_PERCENTAGE=$PHP_OPCACHE_MAX_WASTED_PERCENTAGE_ARG
 ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
-# MozJPEG
-ENV MOZJPEG_VERSION="3.3.1"
-ENV MOZJPEG_BUILD_DEPS \
-    autoconf \
-    automake \
-    build-base \
-    libtool \
-    nasm \
-    pkgconf \
-    tar
-
 RUN set -ex \
     && apk upgrade --no-cache \
     && apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS \
-    $MOZJPEG_BUILD_DEPS \
     freetype-dev \
     icu-dev \
     icu-data-full \
@@ -90,18 +99,10 @@ RUN set -ex \
     redis
 
 # MozJPEG
-WORKDIR /tmp
-ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
-RUN set -ex \
-    && tar -xzf v${MOZJPEG_VERSION}.tar.gz \
-    && cd ./mozjpeg-${MOZJPEG_VERSION} \
-    && autoreconf -fiv \
-    && ./configure --with-jpeg8 \
-    && make \
-    && make install
-
-RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran
-RUN ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/jpegtran /opt/mozjpeg/bin/jpegtran
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/cjpeg /opt/mozjpeg/bin/cjpeg
+RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran \
+    && ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
 
 # Cleanup
 RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
-FROM alpine:3.19 AS mozjpeg-build
+FROM alpine:3.18 AS mozjpeg-build
 ENV MOZJPEG_VERSION="3.3.1"
 
 ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
@@ -96,16 +96,8 @@ RUN set -ex \
     redis \
     && docker-php-ext-enable \
     imagick \
-    redis
-
-# MozJPEG
-COPY --from=mozjpeg-build /opt/mozjpeg/bin/jpegtran /opt/mozjpeg/bin/jpegtran
-COPY --from=mozjpeg-build /opt/mozjpeg/bin/cjpeg /opt/mozjpeg/bin/cjpeg
-RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran \
-    && ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
-
-# Cleanup
-RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
+    redis \
+    && RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
     | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
     | sort -u \
     | xargs -r apk info --installed \
@@ -113,6 +105,12 @@ RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \
     && apk add --no-cache --virtual .runtime-deps $RUNTIME_DEPS \
     && apk del --no-network .build-deps \
     && rm -rf /tmp/*
+
+# MozJPEG
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/jpegtran /opt/mozjpeg/bin/jpegtran
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/cjpeg /opt/mozjpeg/bin/cjpeg
+RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran \
+    && ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
 
 # copy custom.ini settings
 COPY craft-cms.ini /usr/local/etc/php/conf.d/

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,10 +1,6 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
-FROM alpine:3.13 AS iconv-build
-RUN apk upgrade --no-cache \
-    && apk add --no-cache gnu-libiconv
-
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.18
 
 # setup general options for environment variables
@@ -71,6 +67,7 @@ RUN set -ex \
     libwebp-tools \
     optipng \
     pngquant \
+    gnu-libiconv \
     && docker-php-ext-configure gd \
     --with-freetype \
     --with-jpeg \
@@ -91,12 +88,6 @@ RUN set -ex \
     && docker-php-ext-enable \
     imagick \
     redis
-
-# https://github.com/craftcms/docker/issues/16
-COPY --from=iconv-build /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libiconv.so
-
-# https://github.com/docker-library/php/issues/1121
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 # MozJPEG
 WORKDIR /tmp

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,6 +1,27 @@
 ARG PHP_VERSION
 ARG PROJECT_TYPE
 
+FROM alpine:3.19 AS mozjpeg-build
+ENV MOZJPEG_VERSION="3.3.1"
+
+ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
+RUN set -ex \
+  && apk upgrade --no-cache \
+  && apk add --no-cache --virtual .build-deps \
+    autoconf \
+    automake \
+    build-base \
+    libtool \
+    nasm \
+    pkgconf \
+    tar \
+  && tar -xzf v${MOZJPEG_VERSION}.tar.gz \
+  && cd ./mozjpeg-${MOZJPEG_VERSION} \
+  && autoreconf -fiv \
+  && ./configure --with-jpeg8 \
+  && make \
+  && make install
+
 FROM php:${PHP_VERSION}-${PROJECT_TYPE}-alpine3.18
 
 # setup general options for environment variables
@@ -33,22 +54,10 @@ ENV PHP_OPCACHE_MAX_WASTED_PERCENTAGE=$PHP_OPCACHE_MAX_WASTED_PERCENTAGE_ARG
 ENV PHP_OPCACHE_INTERNED_STRINGS_BUFFER=$PHP_OPCACHE_INTERNED_STRINGS_BUFFER_ARG
 ENV PHP_OPCACHE_FAST_SHUTDOWN=$PHP_OPCACHE_FAST_SHUTDOWN_ARG
 
-# MozJPEG
-ENV MOZJPEG_VERSION="3.3.1"
-ENV MOZJPEG_BUILD_DEPS \
-    autoconf \
-    automake \
-    build-base \
-    libtool \
-    nasm \
-    pkgconf \
-    tar
-
 RUN set -ex \
     && apk upgrade --no-cache \
     && apk add --no-cache --virtual .build-deps \
     $PHPIZE_DEPS \
-    $MOZJPEG_BUILD_DEPS \
     freetype-dev \
     icu-dev \
     icu-data-full \
@@ -90,18 +99,10 @@ RUN set -ex \
     redis
 
 # MozJPEG
-WORKDIR /tmp
-ADD https://github.com/mozilla/mozjpeg/archive/v${MOZJPEG_VERSION}.tar.gz ./
-RUN set -ex \
-    && tar -xzf v${MOZJPEG_VERSION}.tar.gz \
-    && cd ./mozjpeg-${MOZJPEG_VERSION} \
-    && autoreconf -fiv \
-    && ./configure --with-jpeg8 \
-    && make \
-    && make install
-
-RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran
-RUN ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/jpegtran /opt/mozjpeg/bin/jpegtran
+COPY --from=mozjpeg-build /opt/mozjpeg/bin/cjpeg /opt/mozjpeg/bin/cjpeg
+RUN ln -s /opt/mozjpeg/bin/jpegtran /usr/local/bin/mozjpegtran \
+    && ln -s /opt/mozjpeg/bin/cjpeg /usr/local/bin/mozcjpeg
 
 # Cleanup
 RUN RUNTIME_DEPS="$(scanelf --needed --nobanner --recursive /usr/local \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,11 +12,11 @@ COPY craftcms/general.conf /etc/nginx/craftcms/
 COPY craftcms/php_fastcgi.conf /etc/nginx/craftcms/
 COPY craftcms/security.conf /etc/nginx/craftcms/
 COPY ${NGINX_CONF} /etc/nginx/conf.d/default.conf
-RUN touch /run/nginx.pid
-RUN touch /run/supervisord.pid
-RUN chown www-data /run/nginx.pid
-RUN chown www-data /run/supervisord.pid
-RUN chown -R www-data:www-data /var/lib/nginx/
+RUN touch /run/nginx.pid \
+    && touch /run/supervisord.pid \
+    && chown www-data /run/nginx.pid \
+    && chown www-data /run/supervisord.pid \
+    && chown -R www-data:www-data /var/lib/nginx/
 USER www-data
 
 EXPOSE 8080

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -16,7 +16,7 @@ RUN touch /run/nginx.pid \
     && touch /run/supervisord.pid \
     && chown www-data /run/nginx.pid \
     && chown www-data /run/supervisord.pid \
-    && chown -R www-data:www-data /var/lib/nginx/
+    && chown -RL www-data:www-data /var/lib/nginx/
 USER www-data
 
 EXPOSE 8080


### PR DESCRIPTION
### Description
- gnu-libiconv issues should be solved and is now installed using apk
- mozjpeg is moved to a separate build stage
- cleanup is merged with the RUN command that installs and uses the tools
- merged other RUN commands just to save layers

I've only changed PHP 8.2 and 8.1 since 8.0 is EOL. Images are building, but I didn't test them yet.

### Related issues
#94